### PR TITLE
Menu slides in

### DIFF
--- a/src/Banner.js
+++ b/src/Banner.js
@@ -52,7 +52,7 @@ class Banner extends Component {
         <div id='hamburger' onClick={this.handleClick}><i className={this.state.isVisible ? 'fas fa-times' : 'fas fa-bars'} /></div>
         <img id='logo' src='/negroni.ico' alt='Chin Chin logo'></img>
         <div id='chin-chin'>Chin Chin</div>
-        <div id='menu' className={this.state.isVisible ? 'visible' : 'hidden'}>
+        <div id='menu' className={this.state.isVisible ? 'menu-visible' : 'menu-hidden'}>
           <Link to={homeAdd}><div className='menu-item'><span className='menu-icon'><i className='fas fa-home' /></span> Home</div></Link>
           <Link to={cocktailsAdd}><div className='menu-item'><span className='menu-icon'><i className='fas fa-cocktail' /></span> Cocktails</div></Link>
           {!loggedIn && <Link to={signInAdd}><div className='menu-item'><span className='menu-icon'><i class='fas fa-sign-in-alt' /></span> Sign In</div></Link>}

--- a/src/main.css
+++ b/src/main.css
@@ -13,11 +13,11 @@ body {
   min-height: 100%;
   padding: 0;
   font-family: Georgia, 'Times New Roman', Times, serif;
-  background-color: #ef845a;
-  background-image: linear-gradient(#ef845a, #cd324c);
   background-attachment: fixed;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #ef845a;
+  background-image: linear-gradient(#ef845a, #cd324c);
 }
 
 a:link {
@@ -71,8 +71,18 @@ a:link {
   box-shadow: 0 4px 4px 0 #00000080;
   border-radius: 0 0 5px 5px;
   width: max-content;
-  padding: 5px 25px;
+  padding: 5px 22px;
   background-color: #444444;
+  transition: all 0.5s ease;
+  height: 100vh;
+}
+
+.menu-hidden {
+  margin-left: -248px;
+}
+
+.menu-visible {
+  margin-left: 0px;
 }
 
 .hidden {


### PR DESCRIPTION
I added `height: 100vh;` to the menu styling which makes it take up the entire height of the screen. We can add some more text to the bottom of the menu (names and GitHub links etc.) to fill the space. Or just remove that line if there's nothing we want to add to it.