### PR TITLE
Added iOS gradient fix and amended single cocktail page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ class App extends Component {
         <div>
           <Banner />
           <Notifications />
+          <div id='gradient' />
           <div id='page-content'>
             <Route exact path="/" component={Home.go} />
             <Route exact path="/cocktails/all" component={CocktailsAll} />

--- a/src/CocktailDetails.js
+++ b/src/CocktailDetails.js
@@ -25,7 +25,7 @@ import React, { Component } from 'react';
     render() {
 	    const { cocktail } = this.state;
 	    return (
-	      <div>
+	      <div className='cocktail-details-parent'>
 	      {cocktail.map(cocktail => {
 	        return <CocktailDetailsItem cocktail={cocktail} />
 	      })}

--- a/src/main.css
+++ b/src/main.css
@@ -13,11 +13,19 @@ body {
   min-height: 100%;
   padding: 0;
   font-family: Georgia, 'Times New Roman', Times, serif;
-  background-attachment: fixed;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+#gradient {
+  background-attachment: initial;
   background-color: #ef845a;
   background-image: linear-gradient(#ef845a, #cd324c);
+  background-size: auto 100vh;
+  position: fixed;
+  z-index: -1;
+  height: 100%;
+  width: 100%;
 }
 
 a:link {
@@ -235,11 +243,15 @@ a:link {
 
 /* #region single cocktail */
 
+.cocktail-details-parent {
+  padding-top: 100px;
+}
+
 .indi-cocktail {
   flex-wrap: wrap;
   display: flex;
   padding: 30px 30px;
-  margin: 100px auto;
+  margin: auto auto;
   width: fit-content;
 }
 
@@ -259,17 +271,24 @@ a:link {
   font-weight: bold;
 }
 
-@media screen and (max-width: 540px) {
+@media screen and (max-width: 860px) {
+
+  .cocktail-details-parent {
+    padding-top: 80px;
+    margin-bottom: 20px;
+  }
 
   #cocktail-image, #cocktail-details {
     width: 275px;
     margin: 0 auto;
-    padding: 25px 0 0 0;
+    padding: 10px 0;
   }
 
   .indi-cocktail {
+    width: 90%;
     padding: 10px 10px;
-    margin: 70px 10px;
+    flex-wrap: nowrap;
+    display: block;
   }
 
   .full-size {
@@ -377,7 +396,7 @@ a:link {
 }
 
 .section {
-  margin-bottom: 25px; 
+  margin-bottom: 25px;
 }
 
 .section-header {


### PR DESCRIPTION
The background gradient had issues on iOS -- it stretched the entire length of the page and scrolled with it rather than being the exact height of the display and fixed in place as it is on desktop (apparently this CSS feature is disabled on iOS). I've worked around this by creating a separate div in App.js to hold the gradient and then fixing it in place with some CSS. There's a slight issue where scrolling upwards on iOS sometimes shows a white bar at the bottom for a moment. It's a trade-off which we prefer really? I've also amended the styling on the single cocktail page.